### PR TITLE
Fix imports in passthrough example

### DIFF
--- a/examples/passthrough/passthrough.go
+++ b/examples/passthrough/passthrough.go
@@ -14,11 +14,12 @@
 package main
 
 import (
-	"cgofuse/fuse"
 	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/billziss-gh/cgofuse/fuse"
 )
 
 var (

--- a/examples/passthrough/port_darwin.go
+++ b/examples/passthrough/port_darwin.go
@@ -16,8 +16,9 @@
 package main
 
 import (
-	"cgofuse/fuse"
 	"syscall"
+
+	"github.com/billziss-gh/cgofuse/fuse"
 )
 
 func setuidgid() func() {

--- a/examples/passthrough/port_linux.go
+++ b/examples/passthrough/port_linux.go
@@ -16,8 +16,9 @@
 package main
 
 import (
-	"cgofuse/fuse"
 	"syscall"
+
+	"github.com/billziss-gh/cgofuse/fuse"
 )
 
 func setuidgid() func() {


### PR DESCRIPTION
I suspect you might have symlinks in your GOPATH or something like that...

The patch changes the imports to be done in the standard go way.