### PR TITLE
Use -z with fusermount to allow unmount if mount is busy

### DIFF
--- a/fuse/host.go
+++ b/fuse/host.go
@@ -437,6 +437,7 @@ static int hostUnmount(struct fuse *fuse, char *mountpoint)
 	char *argv[] =
 	{
 		"/bin/fusermount",
+		"-z",
 		"-u",
 		mountpoint,
 		0,


### PR DESCRIPTION
This is arguably the same as MNT_FORCE as used in the other cases.

Without this when stuff goes wrong in my unit tests I have to manually `fusermount -z -u` the mount