### PR TITLE
macos: look in alternate location for macfuse/osxfuse library

### DIFF
--- a/fuse/host_cgo.go
+++ b/fuse/host_cgo.go
@@ -168,7 +168,9 @@ static void *cgofuse_init_fuse(void)
 
 	void *h;
 #if defined(__APPLE__)
-	h = dlopen("/usr/local/lib/libosxfuse.2.dylib", RTLD_NOW);
+	h = dlopen("/usr/local/lib/libfuse.2.dylib", RTLD_NOW); // MacFUSE/OSXFuse >= v4
+	if (0 == h)
+		h = dlopen("/usr/local/lib/libosxfuse.2.dylib", RTLD_NOW); // MacFUSE/OSXFuse < v4
 #elif defined(__FreeBSD__)
 	h = dlopen("libfuse.so.2", RTLD_NOW);
 #elif defined(__NetBSD__)


### PR DESCRIPTION
With MacFUSE i.e. OSXFuse 4.0, the location of the loadable library
has changed to `/usr/local/lib/libfuse.2.dylib` instead of
`/usr/local/lib/libosxfuse.2.dylib`. The older path is still present
for backwards compatibility for the time being.

This patch looks in the newer location first, then in the older
location if that fails.

Release Notes: https://github.com/osxfuse/osxfuse/releases/tag/macfuse-4.0.0

Fixes #52
