### PR TITLE
allow passing libfuse.dylib path via env variable

### DIFF
--- a/fuse/host_cgo.go
+++ b/fuse/host_cgo.go
@@ -171,18 +171,16 @@ static void *cgofuse_init_fuse(void)
 
 	void *h;
 #if defined(__APPLE__)
-	h = dlopen("/usr/local/lib/libfuse.2.dylib", RTLD_NOW); // MacFUSE/OSXFuse >= v4
+	// runtime path for bundled dylib in e.g. Awesome.app/Contents/Frameworks/libfuse.dylib
+	const char *dylib_path = getenv("CGOFUSE_LIBFUSE_PATH");
+	if(dylib_path)
+		h = dlopen(dylib_path, RTLD_NOW);
+	if (0 == h)
+		h = dlopen("/usr/local/lib/libfuse.2.dylib", RTLD_NOW); // MacFUSE/OSXFuse >= v4
 	if (0 == h)
 		h = dlopen("/usr/local/lib/libosxfuse.2.dylib", RTLD_NOW); // MacFUSE/OSXFuse < v4
 	if (0 == h)
 		h = dlopen("/usr/local/lib/libfuse-t.dylib", RTLD_NOW); // FUSE-T
-	if (0 == h)
-	{
-		// runtime path for bundled dylib in e.g. Awesome.app/Contents/Frameworks/libfuse.dylib
-		const char *dylib_path = getenv("CGOFUSE_LIBFUSE_PATH");
-		if(dylib_path)
-			h = dlopen(dylib_path, RTLD_NOW);
-	}
 #elif defined(__FreeBSD__)
 #if FUSE_USE_VERSION < 30
 	h = dlopen("libfuse.so.2", RTLD_NOW);

--- a/fuse/host_cgo.go
+++ b/fuse/host_cgo.go
@@ -169,7 +169,7 @@ static void *cgofuse_init_fuse(void)
 	if (0 == (*(void **)&(pfn_ ## n) = dlsym(h, #n)))\
 		return 0;
 
-	void *h;
+	void *h = NULL;
 #if defined(__APPLE__)
 	// runtime path for bundled dylib in e.g. Awesome.app/Contents/Frameworks/libfuse.dylib
 	const char *dylib_path = getenv("CGOFUSE_LIBFUSE_PATH");

--- a/fuse/host_cgo.go
+++ b/fuse/host_cgo.go
@@ -176,6 +176,13 @@ static void *cgofuse_init_fuse(void)
 		h = dlopen("/usr/local/lib/libosxfuse.2.dylib", RTLD_NOW); // MacFUSE/OSXFuse < v4
 	if (0 == h)
 		h = dlopen("/usr/local/lib/libfuse-t.dylib", RTLD_NOW); // FUSE-T
+	if (0 == h)
+	{
+		// runtime path for bundled dylib in e.g. Awesome.app/Contents/Frameworks/libfuse.dylib
+		const char *dylib_path = getenv("CGOFUSE_LIBFUSE_PATH");
+		if(dylib_path)
+			h = dlopen(dylib_path, RTLD_NOW);
+	}
 #elif defined(__FreeBSD__)
 #if FUSE_USE_VERSION < 30
 	h = dlopen("libfuse.so.2", RTLD_NOW);

--- a/fuse/host_cgo.go
+++ b/fuse/host_cgo.go
@@ -169,11 +169,11 @@ static void *cgofuse_init_fuse(void)
 	if (0 == (*(void **)&(pfn_ ## n) = dlsym(h, #n)))\
 		return 0;
 
-	void *h = NULL;
+	void *h = 0;
 #if defined(__APPLE__)
 	// runtime path for bundled dylib in e.g. Awesome.app/Contents/Frameworks/libfuse.dylib
 	const char *dylib_path = getenv("CGOFUSE_LIBFUSE_PATH");
-	if(dylib_path)
+	if(0 != dylib_path)
 		h = dlopen(dylib_path, RTLD_NOW);
 	if (0 == h)
 		h = dlopen("/usr/local/lib/libfuse.2.dylib", RTLD_NOW); // MacFUSE/OSXFuse >= v4


### PR DESCRIPTION
I'd like to be able to specify the path to the libfuse dylib within the application bundle to support end users who do not have a fuse implementation installed or do not have admin rights to install a fuse implementation.

I was able to demonstrate that this approach works in a .app file on a system with no fuse implementation installed using fuse-t. The application sets the environment variable, and is then able to use a cgofuse implementation to mount a file system via fuse-t.

Please let me know if there are any style or naming issues that you'd like addressed.