### PR TITLE
fuse: fix libfuse library name on OpenBSD

### DIFF
--- a/fuse/host_cgo.go
+++ b/fuse/host_cgo.go
@@ -190,7 +190,7 @@ static void *cgofuse_init_fuse(void)
 #elif defined(__NetBSD__)
 	h = dlopen("librefuse.so.2", RTLD_NOW);
 #elif defined(__OpenBSD__)
-	h = dlopen("libfuse.so.2.0", RTLD_NOW);
+	h = dlopen("libfuse.so", RTLD_NOW);
 #elif defined(__linux__)
 #if FUSE_USE_VERSION < 30
 	h = dlopen("libfuse.so.2", RTLD_NOW);


### PR DESCRIPTION
libfuse.so.2.0 is long gone. pass the base library name to get the right behavior, as recommended by @jcourreges.

with this, hellofs works on openbsd 7.8.