### PR TITLE
Fix build error on FreeBSD-AMD64

### DIFF
--- a/examples/passthrough/passthrough.go
+++ b/examples/passthrough/passthrough.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || netbsd || openbsd || linux
 // +build darwin freebsd netbsd openbsd linux
 
 /*
@@ -67,7 +68,8 @@ func (self *Ptfs) Mknod(path string, mode uint32, dev uint64) (errc int) {
 	defer trace(path, mode, dev)(&errc)
 	defer setuidgid()()
 	path = filepath.Join(self.root, path)
-	return errno(syscall.Mknod(path, mode, int(dev)))
+	errc = errno(syscall_Mknod(path, mode, dev))
+	return
 }
 
 func (self *Ptfs) Mkdir(path string, mode uint32) (errc int) {

--- a/examples/passthrough/passthrough.go
+++ b/examples/passthrough/passthrough.go
@@ -67,7 +67,7 @@ func (self *Ptfs) Mknod(path string, mode uint32, dev uint64) (errc int) {
 	defer trace(path, mode, dev)(&errc)
 	defer setuidgid()()
 	path = filepath.Join(self.root, path)
-	return errno(syscall.Mknod(path, mode, int(dev)))
+	return errno(syscall_Mknod(path, mode, dev))
 }
 
 func (self *Ptfs) Mkdir(path string, mode uint32) (errc int) {

--- a/examples/passthrough/port_darwin.go
+++ b/examples/passthrough/port_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 /*
@@ -69,4 +70,8 @@ func copyFusestatFromGostat(dst *fuse.Stat_t, src *syscall.Stat_t) {
 
 func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	return syscall.Statfs(path, stat)
+}
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, int(dev))
 }

--- a/examples/passthrough/port_darwin.go
+++ b/examples/passthrough/port_darwin.go
@@ -70,3 +70,7 @@ func copyFusestatFromGostat(dst *fuse.Stat_t, src *syscall.Stat_t) {
 func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	return syscall.Statfs(path, stat)
 }
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, int(dev))
+}

--- a/examples/passthrough/port_freebsd.go
+++ b/examples/passthrough/port_freebsd.go
@@ -1,3 +1,4 @@
+//go:build freebsd
 // +build freebsd
 
 /*
@@ -69,4 +70,8 @@ func copyFusestatFromGostat(dst *fuse.Stat_t, src *syscall.Stat_t) {
 
 func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	return syscall.Statfs(path, stat)
+}
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, dev)
 }

--- a/examples/passthrough/port_freebsd.go
+++ b/examples/passthrough/port_freebsd.go
@@ -70,3 +70,7 @@ func copyFusestatFromGostat(dst *fuse.Stat_t, src *syscall.Stat_t) {
 func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	return syscall.Statfs(path, stat)
 }
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, dev)
+}

--- a/examples/passthrough/port_linux.go
+++ b/examples/passthrough/port_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*
@@ -68,4 +69,8 @@ func copyFusestatFromGostat(dst *fuse.Stat_t, src *syscall.Stat_t) {
 
 func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	return syscall.Statfs(path, stat)
+}
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, int(dev))
 }

--- a/examples/passthrough/port_linux.go
+++ b/examples/passthrough/port_linux.go
@@ -69,3 +69,7 @@ func copyFusestatFromGostat(dst *fuse.Stat_t, src *syscall.Stat_t) {
 func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	return syscall.Statfs(path, stat)
 }
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, int(dev))
+}

--- a/examples/passthrough/port_netbsd.go
+++ b/examples/passthrough/port_netbsd.go
@@ -1,3 +1,4 @@
+//go:build netbsd
 // +build netbsd
 
 /*
@@ -62,4 +63,8 @@ func copyFusestatFromGostat(dst *fuse.Stat_t, src *syscall.Stat_t) {
 func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	*stat = syscall.Statfs_t{}
 	return nil
+}
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, int(dev))
 }

--- a/examples/passthrough/port_netbsd.go
+++ b/examples/passthrough/port_netbsd.go
@@ -63,3 +63,7 @@ func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	*stat = syscall.Statfs_t{}
 	return nil
 }
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, int(dev))
+}

--- a/examples/passthrough/port_openbsd.go
+++ b/examples/passthrough/port_openbsd.go
@@ -1,3 +1,4 @@
+//go:build openbsd
 // +build openbsd
 
 /*
@@ -69,4 +70,8 @@ func copyFusestatFromGostat(dst *fuse.Stat_t, src *syscall.Stat_t) {
 
 func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	return syscall.Statfs(path, stat)
+}
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, int(dev))
 }

--- a/examples/passthrough/port_openbsd.go
+++ b/examples/passthrough/port_openbsd.go
@@ -70,3 +70,7 @@ func copyFusestatFromGostat(dst *fuse.Stat_t, src *syscall.Stat_t) {
 func syscall_Statfs(path string, stat *syscall.Statfs_t) error {
 	return syscall.Statfs(path, stat)
 }
+
+func syscall_Mknod(path string, mode uint32, dev uint64) error {
+	return syscall.Mknod(path, mode, int(dev))
+}


### PR DESCRIPTION
Fixes the issue #102 by adding syscall wrappers in port_*.go files